### PR TITLE
動的フォームの初期値に外部データを設定できるように設定。

### DIFF
--- a/app/dev/form/page.tsx
+++ b/app/dev/form/page.tsx
@@ -1,10 +1,25 @@
 import { Box } from "@mui/material";
+import { DynamicForm } from "./shared/components/dynamic-form/dynamic-form";
 import MyRating from "./shared/components/rating";
 import MyRatingNonCtlState from "./shared/components/rating-non-ctl-state";
 import MyRatingNonCtlWatch from "./shared/components/rating-non-ctl-watch";
-import { DynamicForm } from "./shared/components/dynamic-form/dynamic-form";
 
+type RecordsObj = {
+  records?: {
+    unitPrice: number;
+    amount: number;
+  }[];
+};
 export default function Page() {
+  // レコードのテストデータ(空の場合は空のオブジェクトを渡す)
+  // const recordsObj: RecordsObj = {};
+  const recordsObj: RecordsObj = {
+    records: [
+      { unitPrice: 100, amount: 1 },
+      { unitPrice: 200, amount: 2 },
+    ],
+  };
+
   return (
     <main>
       <div className="mb-4">
@@ -19,7 +34,7 @@ export default function Page() {
             <MyRatingNonCtlWatch />
           </Box>
           <Box sx={{ my: 6 }}>
-            <DynamicForm />
+            <DynamicForm records={recordsObj.records} />
           </Box>
         </Box>
       </div>

--- a/app/dev/form/page.tsx
+++ b/app/dev/form/page.tsx
@@ -3,17 +3,12 @@ import { DynamicForm } from "./shared/components/dynamic-form/dynamic-form";
 import MyRating from "./shared/components/rating";
 import MyRatingNonCtlState from "./shared/components/rating-non-ctl-state";
 import MyRatingNonCtlWatch from "./shared/components/rating-non-ctl-watch";
+import type { DynamicFormRecordsObj } from "./shared/components/types/dynamic-form";
 
-type RecordsObj = {
-  records?: {
-    unitPrice: number;
-    amount: number;
-  }[];
-};
 export default function Page() {
   // レコードのテストデータ(空の場合は空のオブジェクトを渡す)
-  // const recordsObj: RecordsObj = {};
-  const recordsObj: RecordsObj = {
+  // const recordsObj: DynamicFormRecordsObj = {};
+  const recordsObj: DynamicFormRecordsObj = {
     records: [
       { unitPrice: 100, amount: 1 },
       { unitPrice: 200, amount: 2 },

--- a/app/dev/form/shared/components/dynamic-form/dynamic-form.tsx
+++ b/app/dev/form/shared/components/dynamic-form/dynamic-form.tsx
@@ -35,8 +35,15 @@ const schema = z.object({
 });
 
 export type Schema = z.infer<typeof schema>;
+type Props = {
+  records?: {
+    unitPrice: number;
+    amount: number;
+  }[];
+};
 
-export function DynamicForm() {
+export function DynamicForm(props: Props) {
+  const { records } = props;
   const {
     register,
     control,
@@ -45,7 +52,9 @@ export function DynamicForm() {
   } = useForm<Schema>({
     resolver: zodResolver(schema),
     defaultValues: {
-      records: [{ unitPrice: undefined as never, amount: undefined as never }],
+      records: records
+        ? records
+        : [{ unitPrice: undefined as never, amount: undefined as never }],
     },
   });
   const { fields, append, remove } = useFieldArray({

--- a/app/dev/form/shared/components/types/dynamic-form.ts
+++ b/app/dev/form/shared/components/types/dynamic-form.ts
@@ -1,0 +1,6 @@
+export type DynamicFormRecordsObj = {
+  records?: {
+    unitPrice: number;
+    amount: number;
+  }[];
+};


### PR DESCRIPTION
## オブジェクトの中身が空の場合
```typescript
  const recordsObj: DynamicFormRecordsObj = {
    records: [
      { unitPrice: 100, amount: 1 },
      { unitPrice: 200, amount: 2 },
    ],
  };
```
<img width="589" alt="スクリーンショット 2025-01-13 11 08 56" src="https://github.com/user-attachments/assets/318e9b12-1e8a-4e0b-bef5-1e29345f4235" />

## オブジェクトの中身が空の場合
```typescript
  const recordsObj: DynamicFormRecordsObj = {};
```
<img width="478" alt="スクリーンショット 2025-01-13 11 12 25" src="https://github.com/user-attachments/assets/27176165-00bb-4846-bedb-417a2bf29594" />
