### PR TITLE
ナビゲーションバーにDrawerを統合

### DIFF
--- a/app/[lang]/dev/form/page.tsx
+++ b/app/[lang]/dev/form/page.tsx
@@ -27,24 +27,24 @@ export default async function Page({ params }: PageProps) {
 
   return (
     <main>
-      <div className="text-2xl font-bold">{t("common:title")}</div>
-      <div className="mb-4">
+      <Box
+        sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
+      >
+        <div className="text-2xl font-bold">{t("common:title")}</div>
         <div className="text-2xl font-bold">{lang}</div>
-        <Box display="flex" flexDirection="column" alignItems="center">
-          <Box sx={{ my: 6 }}>
-            <MyRating />
-          </Box>
-          <Box sx={{ my: 6 }}>
-            <MyRatingNonCtlState />
-          </Box>
-          <Box sx={{ my: 6 }}>
-            <MyRatingNonCtlWatch />
-          </Box>
-          <Box sx={{ my: 6 }}>
-            <DynamicForm records={recordsObj.records} />
-          </Box>
+        <Box sx={{ my: 6 }}>
+          <MyRating />
         </Box>
-      </div>
+        <Box sx={{ my: 6 }}>
+          <MyRatingNonCtlState />
+        </Box>
+        <Box sx={{ my: 6 }}>
+          <MyRatingNonCtlWatch />
+        </Box>
+        <Box sx={{ my: 6 }}>
+          <DynamicForm records={recordsObj.records} />
+        </Box>
+      </Box>
     </main>
   );
 }

--- a/app/[lang]/dev/form/ui/app-container.tsx
+++ b/app/[lang]/dev/form/ui/app-container.tsx
@@ -1,6 +1,6 @@
 "use client";
-import NavBar from "@/app/[lang]/dev/form/ui/nav-bar";
-import { Container as MuiContainer, styled } from "@mui/material";
+import Container from "@/app/[lang]/dev/form/ui/container";
+import { styled } from "@mui/material";
 import { PropsWithChildren } from "react";
 
 const AppContent = styled("div")({
@@ -11,18 +11,10 @@ const AppContent = styled("div")({
   height: "100%",
 });
 
-const Container = styled(MuiContainer)({
-  height: "100%",
-});
-
-const Offset = styled("div")(({ theme }) => theme.mixins.toolbar);
-
 export default function AppContainer({ children }: PropsWithChildren) {
   return (
     <div lang="ja">
       <AppContent>
-        <NavBar />
-        <Offset />
         <Container>{children}</Container>
       </AppContent>
     </div>

--- a/app/[lang]/dev/form/ui/container.tsx
+++ b/app/[lang]/dev/form/ui/container.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { DRAWER_WIDTH } from "@/app/constants/styles";
+import { styled } from "@mui/material";
+import { useState } from "react";
+import NavBar from "./nav-bar";
+
+export default function Container({ children }: { children: React.ReactNode }) {
+  const [isDrawerOpen, setDrawerOpen] = useState(false);
+
+  const handleDrawerToggle = () => {
+    setDrawerOpen(!isDrawerOpen);
+  };
+
+  const Offset = styled("div")(({ theme }) => theme.mixins.toolbar);
+
+  const Main = styled("main", {
+    shouldForwardProp: (prop) => prop !== "open",
+  })<{
+    open?: boolean;
+  }>(({ theme }) => ({
+    height: "100%",
+    flexGrow: 1,
+    padding: theme.spacing(3),
+    transition: theme.transitions.create("margin", {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+    // Drawerを開いた時にコンテンツが隠れないようにDrawerの幅分マージンを追加
+    marginLeft: `-${DRAWER_WIDTH}px`,
+    // 上記のマージンの影響でコンテンツが左寄せになるので、追加したマージン分だけパディングで埋める
+    paddingLeft: `${DRAWER_WIDTH}px`,
+    // propsのopenがtrueの時に適用するスタイル
+    variants: [
+      {
+        props: { open: true },
+        style: {
+          transition: theme.transitions.create("margin", {
+            easing: theme.transitions.easing.easeOut,
+            duration: theme.transitions.duration.enteringScreen,
+          }),
+          marginLeft: 0,
+        },
+      },
+    ],
+  }));
+
+  return (
+    <>
+      <NavBar
+        isDrawerOpen={isDrawerOpen}
+        handleDrawerToggle={handleDrawerToggle}
+      ></NavBar>
+      <Offset />
+      <Main open={isDrawerOpen}>{children}</Main>
+    </>
+  );
+}

--- a/app/[lang]/dev/form/ui/custom-drawer.tsx
+++ b/app/[lang]/dev/form/ui/custom-drawer.tsx
@@ -1,0 +1,86 @@
+"use clinent";
+import { DRAWER_WIDTH } from "@/app/constants/styles";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import MailIcon from "@mui/icons-material/Mail";
+import InboxIcon from "@mui/icons-material/MoveToInbox";
+import {
+  Divider,
+  Drawer,
+  IconButton,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  styled,
+  useTheme,
+} from "@mui/material";
+type Props = {
+  isDrawerOpen: boolean;
+  handleDrawerToggle: () => void;
+};
+export default function CustomDrawer(props: Props) {
+  const { isDrawerOpen, handleDrawerToggle } = props;
+  const theme = useTheme();
+  const DrawerHeader = styled("div")(({ theme }) => ({
+    display: "flex",
+    alignItems: "center",
+    padding: theme.spacing(0, 1),
+    // necessary for content to be below app bar
+    ...theme.mixins.toolbar,
+    justifyContent: "flex-end",
+  }));
+
+  return (
+    <Drawer
+      sx={{
+        width: DRAWER_WIDTH,
+        flexShrink: 0,
+        "& .MuiDrawer-paper": {
+          width: DRAWER_WIDTH,
+          boxSizing: "border-box",
+        },
+      }}
+      variant="persistent"
+      anchor="left"
+      open={isDrawerOpen}
+    >
+      <DrawerHeader>
+        <IconButton onClick={handleDrawerToggle}>
+          {theme.direction === "ltr" ? (
+            <ChevronLeftIcon />
+          ) : (
+            <ChevronRightIcon />
+          )}
+        </IconButton>
+      </DrawerHeader>
+      <Divider />
+      <List>
+        {["Inbox", "Starred", "Send email", "Drafts"].map((text, index) => (
+          <ListItem key={text} disablePadding>
+            <ListItemButton>
+              <ListItemIcon>
+                {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+              </ListItemIcon>
+              <ListItemText primary={text} />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+      <Divider />
+      <List>
+        {["All mail", "Trash", "Spam"].map((text, index) => (
+          <ListItem key={text} disablePadding>
+            <ListItemButton>
+              <ListItemIcon>
+                {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+              </ListItemIcon>
+              <ListItemText primary={text} />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+    </Drawer>
+  );
+}

--- a/app/[lang]/dev/form/ui/custom-drawer.tsx
+++ b/app/[lang]/dev/form/ui/custom-drawer.tsx
@@ -1,4 +1,4 @@
-"use clinent";
+"use client";
 import { DRAWER_WIDTH } from "@/app/constants/styles";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";

--- a/app/[lang]/dev/form/ui/nav-bar.tsx
+++ b/app/[lang]/dev/form/ui/nav-bar.tsx
@@ -14,7 +14,7 @@ import MenuItem from "@mui/material/MenuItem";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import * as React from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "@/app/i18n/client";
 import AppLogo from "./app-logo";
 
 export default function NavBar() {

--- a/app/[lang]/dev/form/ui/nav-bar.tsx
+++ b/app/[lang]/dev/form/ui/nav-bar.tsx
@@ -1,28 +1,43 @@
 "use client";
+import { DRAWER_WIDTH } from "@/app/constants/styles";
+import { useTranslation } from "@/app/i18n/client";
 import { useLanguage } from "@/context/language-context";
 import AccountCircle from "@mui/icons-material/AccountCircle";
 import MailIcon from "@mui/icons-material/Mail";
 import MenuIcon from "@mui/icons-material/Menu";
 import MoreIcon from "@mui/icons-material/MoreVert";
 import NotificationsIcon from "@mui/icons-material/Notifications";
-import AppBar from "@mui/material/AppBar";
-import Badge from "@mui/material/Badge";
-import Box from "@mui/material/Box";
-import IconButton from "@mui/material/IconButton";
-import Menu from "@mui/material/Menu";
-import MenuItem from "@mui/material/MenuItem";
-import Toolbar from "@mui/material/Toolbar";
-import Typography from "@mui/material/Typography";
-import * as React from "react";
-import { useTranslation } from "@/app/i18n/client";
+import {
+  Badge,
+  Box,
+  IconButton,
+  Menu,
+  MenuItem,
+  AppBar as MuiAppBar,
+  AppBarProps as MuiAppBarProps,
+  styled,
+  Toolbar,
+  Typography,
+} from "@mui/material";
+import { useState } from "react";
 import AppLogo from "./app-logo";
+import CustomDrawer from "./custom-drawer";
 
-export default function NavBar() {
+type Props = {
+  isDrawerOpen: boolean;
+  handleDrawerToggle: () => void;
+};
+
+export default function NavBar(props: Props) {
+  const { isDrawerOpen, handleDrawerToggle } = props;
+  interface AppBarProps extends MuiAppBarProps {
+    open?: boolean;
+  }
   const { language: lang } = useLanguage();
   const { t } = useTranslation(lang);
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [mobileMoreAnchorEl, setMobileMoreAnchorEl] =
-    React.useState<null | HTMLElement>(null);
+    useState<null | HTMLElement>(null);
 
   const isMenuOpen = Boolean(anchorEl);
   const isMobileMenuOpen = Boolean(mobileMoreAnchorEl);
@@ -44,10 +59,33 @@ export default function NavBar() {
     setMobileMoreAnchorEl(event.currentTarget);
   };
 
+  const AppBar = styled(MuiAppBar, {
+    shouldForwardProp: (prop) => prop !== "open",
+  })<AppBarProps>(({ theme }) => ({
+    transition: theme.transitions.create(["margin", "width"], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+    variants: [
+      {
+        props: { open: true },
+        style: {
+          width: `calc(100% - ${DRAWER_WIDTH}px)`,
+          marginLeft: `${DRAWER_WIDTH}px`,
+          transition: theme.transitions.create(["margin", "width"], {
+            easing: theme.transitions.easing.easeOut,
+            duration: theme.transitions.duration.enteringScreen,
+          }),
+        },
+      },
+    ],
+  }));
+
   const menuId = "primary-search-account-menu";
   const renderMenu = (
     <Menu
-      anchorEl={anchorEl}
+      //エラーになるので一旦コメントアウト
+      // anchorEl={anchorEl}
       anchorOrigin={{
         vertical: "top",
         horizontal: "right",
@@ -69,7 +107,8 @@ export default function NavBar() {
   const mobileMenuId = "primary-search-account-menu-mobile";
   const renderMobileMenu = (
     <Menu
-      anchorEl={mobileMoreAnchorEl}
+      //エラーになるので一旦コメントアウト
+      // anchorEl={mobileMoreAnchorEl}
       anchorOrigin={{
         vertical: "top",
         horizontal: "right",
@@ -120,14 +159,15 @@ export default function NavBar() {
 
   return (
     <Box sx={{ flexGrow: 1 }}>
-      <AppBar color="inherit" position="fixed">
+      <AppBar color="inherit" position="fixed" open={isDrawerOpen}>
         <Toolbar>
           <IconButton
             size="large"
             edge="start"
             color="inherit"
             aria-label="open drawer"
-            sx={{ mr: 2 }}
+            sx={[{ mr: 2 }, isDrawerOpen && { display: "none" }]}
+            onClick={handleDrawerToggle}
           >
             <MenuIcon />
           </IconButton>
@@ -185,6 +225,10 @@ export default function NavBar() {
             </IconButton>
           </Box>
         </Toolbar>
+        <CustomDrawer
+          isDrawerOpen={isDrawerOpen}
+          handleDrawerToggle={handleDrawerToggle}
+        />
       </AppBar>
       {renderMobileMenu}
       {renderMenu}

--- a/app/constants/styles.ts
+++ b/app/constants/styles.ts
@@ -1,0 +1,1 @@
+export const DRAWER_WIDTH = 240;


### PR DESCRIPTION
## PR 概要

### 対応内容

<!-- PRの対応内容とをここに記入する -->
https://github.com/hiroki1216/nextjs-dashboard/pull/5
上記で実装したナビゲーションバーにDrawerを統合しました。

### 実装画面

<!-- 実装画面のイメージをここにアップロードする -->
<img width="1440" alt="スクリーンショット 2025-04-29 22 55 57" src="https://github.com/user-attachments/assets/5ce183d8-ed16-42b5-ac5f-10e61291208e" />

### 参考 URL

<!-- 実装時に参考にしたソースがあればここに記入する -->

- [Persistent drawer](https://mui.com/material-ui/react-drawer/#persistent-drawer)
- [ styled()](https://mui.com/system/styled/)
- [Transitions](https://mui.com/material-ui/customization/transitions/#theme-transitions-create-props-options-transition)

## その他

<!-- その他何かあればここに記入する-->

anchorElの部分でエラーが発生するのでコメントアウトしている。
~~~
Popover.js:156 MUI: The `anchorEl` prop provided to the component is invalid.
The anchor element should be part of the document layout.
Make sure the element is present in the document or that it's not display none.
~~~

~~~typescript
  const renderMenu = (
    <Menu
      //エラーになるので一旦コメントアウト
      // anchorEl={anchorEl}
      anchorOrigin={{
        vertical: "top",
        horizontal: "right",
      }}
      id={menuId}
      keepMounted
      transformOrigin={{
        vertical: "top",
        horizontal: "right",
      }}
      open={isMenuOpen}
      onClose={handleMenuClose}
    >
      <MenuItem onClick={handleMenuClose}>{t("nav-bar:profile")}</MenuItem>
      <MenuItem onClick={handleMenuClose}>{t("nav-bar:myAccount")}</MenuItem>
    </Menu>
  );
~~~

## マージ前の確認事項

<!-- 確認不要な場合は、- [対象外]とすること -->

- [x] ビルドが通っているか
- [対象外] テストが全て通っているか
