### PR TITLE
スクロールトップボタンの実装

### DIFF
--- a/app/[lang]/dev/form/ui/container.tsx
+++ b/app/[lang]/dev/form/ui/container.tsx
@@ -1,8 +1,9 @@
 "use client";
 import { DRAWER_WIDTH } from "@/app/constants/styles";
-import { styled } from "@mui/material";
+import { styled, Toolbar } from "@mui/material";
 import { useState } from "react";
 import NavBar from "./nav-bar";
+import ScrollTopButton from "./scroll-top-button";
 
 export default function Container({ children }: { children: React.ReactNode }) {
   const [isDrawerOpen, setDrawerOpen] = useState(false);
@@ -51,7 +52,9 @@ export default function Container({ children }: { children: React.ReactNode }) {
         handleDrawerToggle={handleDrawerToggle}
       ></NavBar>
       <Offset />
+      <Toolbar id="back-to-top-anchor" />
       <Main open={isDrawerOpen}>{children}</Main>
+      <ScrollTopButton></ScrollTopButton>
     </>
   );
 }

--- a/app/[lang]/dev/form/ui/scroll-top-button.tsx
+++ b/app/[lang]/dev/form/ui/scroll-top-button.tsx
@@ -1,0 +1,38 @@
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import Box from "@mui/material/Box";
+import Fab from "@mui/material/Fab";
+import Fade from "@mui/material/Fade";
+import useScrollTrigger from "@mui/material/useScrollTrigger";
+import { MouseEvent } from "react";
+
+export default function ScrollTopButton() {
+  const trigger = useScrollTrigger({
+    disableHysteresis: true,
+  });
+
+  const handleClick = (event: MouseEvent<HTMLDivElement>) => {
+    const anchor = (
+      (event.target as HTMLDivElement).ownerDocument || document
+    ).querySelector("#back-to-top-anchor");
+
+    if (anchor) {
+      anchor.scrollIntoView({
+        block: "center",
+      });
+    }
+  };
+
+  return (
+    <Fade in={trigger}>
+      <Box
+        onClick={handleClick}
+        role="presentation"
+        sx={{ position: "fixed", bottom: 16, right: 16 }}
+      >
+        <Fab size="small" aria-label="scroll back to top">
+          <KeyboardArrowUpIcon />
+        </Fab>
+      </Box>
+    </Fade>
+  );
+}

--- a/app/[lang]/dev/form/ui/scroll-top-button.tsx
+++ b/app/[lang]/dev/form/ui/scroll-top-button.tsx
@@ -12,7 +12,7 @@ export default function ScrollTopButton() {
 
   const handleClick = (event: MouseEvent<HTMLDivElement>) => {
     const anchor = (
-      (event.target as HTMLDivElement).ownerDocument || document
+      (event.currentTarget as HTMLDivElement).ownerDocument || document
     ).querySelector("#back-to-top-anchor");
 
     if (anchor) {


### PR DESCRIPTION
## PR 概要

### 対応内容

<!-- PRの対応内容とをここに記入する -->
ページが下部にスクロール（閾値100px）した際にページの最上部までスクロールアップするボタンコンポーネントを実装し、コンテンツのコンテナコンポーネントに統合しました。

### 実装画面

<!-- 実装画面のイメージをここにアップロードする -->
<img width="1438" alt="スクリーンショット 2025-04-30 8 36 09" src="https://github.com/user-attachments/assets/b2006718-37fc-4c95-8ba4-d142c81ac314" />


### 参考 URL

<!-- 実装時に参考にしたソースがあればここに記入する -->

- [Back to top](https://mui.com/material-ui/react-app-bar/#back-to-top)

## その他

<!-- その他何かあればここに記入する-->
特になし
## マージ前の確認事項

<!-- 確認不要な場合は、- [対象外]とすること -->

- [ ] ビルドが通っているか
- [対象外] テストが全て通っているか
